### PR TITLE
Add CI workflow and Poetry config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          make deps
+
+      - name: Run pre-commit checks
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
+
+      - name: Build site
+        run: |
+          make update

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ htmlcov/
 
 # Poetry
 dist/
-poetry.toml
 
 # Misc
 .DS_Store

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
## Summary
- Add GitHub workflow for CI to run pre-commit checks and build the site
- Add poetry.toml to ensure in-project virtualenvs
- Update .gitignore to allow poetry.toml to be committed

## Test plan
- GitHub actions should automatically run pre-commit checks and build the site for all branches
- Poetry should create virtualenvs within the project directory

🤖 Generated with [Claude Code](https://claude.ai/code)