### PR TITLE
Add pre-commit hook to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,14 @@ jobs:
         run: |
           make deps
 
-      - name: Run pre-commit checks
+      - name: Run pre-commit checks (excluding tests)
         run: |
           pip install pre-commit
-          pre-commit run --all-files
+          SKIP=pytest pre-commit run --all-files
+
+      - name: Run tests
+        run: |
+          make test
 
       - name: Build site
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,13 @@ repos:
         additional_dependencies: [types-pytz, types-markdown]
         args: [--ignore-missing-imports, --warn-unused-ignores, --warn-redundant-casts, --warn-unreachable]
         files: ^pygen/
+
+  # Run pytest to ensure all tests pass
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: poetry run pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,5 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        # Can be skipped with SKIP=pytest
+        stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,4 @@ repos:
         pass_filenames: false
         always_run: true
         # Can be skipped with SKIP=pytest
-        stages: [commit]
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: poetry run pytest
+        entry: make test
         language: system
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Always run `pre-commit run --all-files` before running `git add` to ensure code formatting
 - Use `make lint` to check for linting issues
 - Use `make format` to fix formatting issues
+- Use `make test` to run the test suite
 - Let the formatter make its changes before committing code
+- All tests must pass before creating a PR
 
 ## Project Structure
 - pygen/: Main Python generation code


### PR DESCRIPTION
## Summary
- Added a pre-commit hook that runs pytest to ensure all tests pass before allowing commits
- Updated CLAUDE.md to reflect testing requirements in the development workflow

## Test plan
- Make changes to code and run `pre-commit run --all`
- Verify that tests run automatically as part of the pre-commit process
- Test will fail if any test fails

🤖 Generated with [Claude Code](https://claude.ai/code)