### PR TITLE
Remove dead code from main.py

### DIFF
--- a/pygen/main.py
+++ b/pygen/main.py
@@ -569,23 +569,6 @@ def GetArticleDict(globalData, article):
     }
 
 
-def GetTemplateDependencies(globalData: GlobalData, template: str, includePath: str) -> set[str]:
-    """Get template dependencies.
-
-    Args:
-        globalData: Global data object
-        template: Template filename
-        includePath: Path to include files
-
-    Returns:
-        Set of template file paths including dependencies
-    """
-    # Process template includes
-    ignored, dependencies = ETL.process_includes(template, includePath)
-    dependencies.add(template)
-    return dependencies
-
-
 def OutputArticleHtml(globalData, article):
     template = globalData.config["ArticleTemplate"]
     articleDirectory = globalData.config["ArticleDirectory"]
@@ -600,22 +583,9 @@ def OutputArticleHtml(globalData, article):
     output.close()
 
 
-def MyMax(objects, key):
-    """Replacement for max(obj, key) as python 2.4 doens't have it"""
-    if not objects:
-        raise ValueError("max() arg is empty")
-    maximum = objects[0]
-    maximumValue = key(maximum)
-    for value in objects[1:]:
-        thisValue = key(value)
-        if thisValue > maximumValue:
-            maximumValue = thisValue
-            maximum = value
-    return maximum
-
-
 def OutputArticles(globalData, articles, template, label, outputName):
-    latestUpdate = MyMax(articles, key=lambda a: a.Dates[-1]).Dates[-1]
+    # Find the article with the most recent update date
+    latestUpdate = max(articles, key=lambda a: a.Dates[-1]).Dates[-1]
     d = {
         "year": str(datetime.datetime.now().year),
         "label": label,
@@ -671,13 +641,14 @@ def Generate(forceGenerate: bool) -> None:
 
     Args:
         forceGenerate: Force regeneration of all files
+
+    Note:
+        The forceGenerate parameter is currently not used.
     """
     globalData = GlobalData()
     ReadGeneratorConfig("generator.conf", globalData)
 
     CheckConfig(globalData)
-    if forceGenerate:
-        globalData.config["ForceRefresh"] = True
 
     ScanArticleDirectory(globalData)
 


### PR DESCRIPTION
## Summary

This PR removes several pieces of dead code from the codebase:

1. **`GetTemplateDependencies` function**: This function was defined but never called in the codebase.

2. **`MyMax` function**: This was a legacy compatibility function for Python 2.4 that has been replaced with the built-in `max()` function.

3. **`ForceRefresh` flag**: This flag was set in the `Generate` function but never read anywhere else.

These changes make the codebase more maintainable by removing unused parts while ensuring all existing functionality works correctly. All tests continue to pass.

Note: The XHTML-related code (XHtmlText generation, contentXHTML in article dictionaries, etc.) was kept as it's actively used in the Atom feed template.

🤖 Generated with [Claude Code](https://claude.ai/code)